### PR TITLE
Add StickyHeader middleware

### DIFF
--- a/middlewares/stickyheader.go
+++ b/middlewares/stickyheader.go
@@ -1,0 +1,88 @@
+package middlewares
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"strings"
+)
+
+const (
+	headerName = "X-Traefik-Backend"
+	queryName  = "X-Traefik-Backend"
+	cookieName = "_TRAEFIK_BACKEND"
+)
+
+// StickyHeader is a middleware that adds X-Traefik-Backend header when sticky
+// cookies are used. Also uses X-Traefik-Backend from a query string when a
+// cookie is not present but sticky cookies are being used.
+type StickyHeader struct {
+	next http.Handler
+}
+
+// NewStickyHeader is called at start
+func NewStickyHeader(next http.Handler) *StickyHeader {
+	return &StickyHeader{next}
+}
+
+type backendHeaderWriter struct {
+	http.ResponseWriter
+}
+
+func (w *backendHeaderWriter) WriteHeader(status int) {
+	if backendLocation := w.getResponseCookieByName(cookieName); backendLocation != "" {
+		// Found backend location cookie. Adding it to headers.
+		w.ResponseWriter.Header().Set(headerName, backendLocation)
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *backendHeaderWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *backendHeaderWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ResponseWriter.(http.Hijacker).Hijack()
+}
+
+func (sh *StickyHeader) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if _, err := req.Cookie(cookieName); err == http.ErrNoCookie {
+		// Cookie is not set. Checking query string for the backend.
+		queryValues := req.URL.Query()
+		if backendLocation := queryValues.Get(queryName); backendLocation != "" {
+			// Got the backend from the header. Setting it as a cookie for sticky module to work.
+			cookie := &http.Cookie{Name: cookieName, Value: backendLocation}
+			req.AddCookie(cookie)
+		}
+	}
+
+	writer := &backendHeaderWriter{w}
+	writer.addOrAppendHeader("Access-Control-Expose-Headers", headerName)
+	sh.next.ServeHTTP(writer, req)
+}
+
+func (w *backendHeaderWriter) getResponseCookieByName(name string) string {
+	headers := w.ResponseWriter.Header()
+	setCookies := headers["Set-Cookie"]
+
+	for _, cookie := range setCookies {
+		elements := strings.Split(cookie, "=")
+		name, value := elements[0], elements[1]
+
+		if name == cookieName {
+			return value
+		}
+	}
+	return ""
+}
+
+func (w *backendHeaderWriter) addOrAppendHeader(name string, value string) {
+	if currentValue := w.ResponseWriter.Header().Get(name); currentValue != "" {
+		newValue := strings.Join([]string{currentValue, value}, ", ")
+		w.ResponseWriter.Header().Set(name, newValue)
+	} else {
+		w.ResponseWriter.Header().Set(name, value)
+	}
+}

--- a/middlewares/stickyheader_test.go
+++ b/middlewares/stickyheader_test.go
@@ -1,0 +1,59 @@
+package middlewares
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStickyHeaderWhenNoStickiness(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	stickyHeader := NewStickyHeader(handler)
+	responseWriter := httptest.NewRecorder()
+
+	request, _ := http.NewRequest("GET", "http://example.com", nil)
+	stickyHeader.ServeHTTP(responseWriter, request)
+
+	response := responseWriter.Result()
+	assert.Equal(t, http.StatusOK, response.StatusCode, "should be successful request")
+}
+
+func TestStickyHeaderSetWhenResponseHasStickyCookie(t *testing.T) {
+	backend := "http://1.2.3.4"
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie := http.Cookie{Name: "_TRAEFIK_BACKEND", Value: backend}
+		http.SetCookie(w, &cookie)
+		w.WriteHeader(http.StatusOK)
+	})
+	stickyHeader := NewStickyHeader(handler)
+	responseWriter := httptest.NewRecorder()
+
+	request, _ := http.NewRequest("GET", "http://example.com", nil)
+	stickyHeader.ServeHTTP(responseWriter, request)
+
+	response := responseWriter.Result()
+	assert.Equal(t, http.StatusOK, response.StatusCode, "should be successful request")
+	assert.Equal(t, backend, response.Header.Get("X-Traefik-Backend"), "should have backend header")
+	assert.Equal(t, "X-Traefik-Backend", response.Header.Get("Access-Control-Expose-Headers"), "should have backend header")
+}
+
+func TestStickyHeaderSetWhenRequestWithBackendHeader(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie, _ := r.Cookie("_TRAEFIK_BACKEND")
+		assert.Equal(t, "http://1.2.3.4", cookie.Value, "should have a request cookie")
+		w.WriteHeader(http.StatusOK)
+	})
+	stickyHeader := NewStickyHeader(handler)
+	responseWriter := httptest.NewRecorder()
+
+	request, _ := http.NewRequest("GET", "http://example.com?X-Traefik-Backend=http://1.2.3.4", nil)
+	stickyHeader.ServeHTTP(responseWriter, request)
+
+	response := responseWriter.Result()
+	assert.Equal(t, http.StatusOK, response.StatusCode, "should be successful request")
+}


### PR DESCRIPTION
This adds backend location information to X-Treafik-Backend header when
sticky sessions are enabled. This is useful when the browser does not
support cookies.

The browser must store and send X-Traefik-Backend header every time
itself (e.g. store it in sessionStorage or somewhere else)

INF-1025