### PR TITLE
Set response cookie if a valid backend in the query string is present

### DIFF
--- a/middlewares/stickyheader_test.go
+++ b/middlewares/stickyheader_test.go
@@ -57,3 +57,71 @@ func TestStickyHeaderSetWhenRequestWithBackendHeader(t *testing.T) {
 	response := responseWriter.Result()
 	assert.Equal(t, http.StatusOK, response.StatusCode, "should be successful request")
 }
+
+func TestStickyHeaderSetsResponseCookieWhenValidCustomHeader(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	stickyHeader := NewStickyHeader(handler)
+	responseWriter := httptest.NewRecorder()
+
+	request, _ := http.NewRequest("GET", "http://example.com?X-Traefik-Backend=http://1.2.3.4", nil)
+	stickyHeader.ServeHTTP(responseWriter, request)
+
+	response := responseWriter.Result()
+	assert.Equal(t, http.StatusOK, response.StatusCode, "should be successful request")
+
+	cookie := getResponseCookieByName(response, "_TRAEFIK_BACKEND")
+	assert.Equal(t, "http://1.2.3.4", cookie, "should use backend from query string")
+	assert.Equal(t, "http://1.2.3.4", response.Header.Get("X-Traefik-Backend"), "should have a sticky header")
+}
+
+func TestStickyHeaderSetsResponseCookieWhenInvalidCustomHeader(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie := http.Cookie{Name: "_TRAEFIK_BACKEND", Value: "http://2.3.4.5"}
+		http.SetCookie(w, &cookie)
+		w.WriteHeader(http.StatusOK)
+	})
+	stickyHeader := NewStickyHeader(handler)
+	responseWriter := httptest.NewRecorder()
+
+	request, _ := http.NewRequest("GET", "http://example.com?X-Traefik-Backend=http://1.2.3.4", nil)
+	stickyHeader.ServeHTTP(responseWriter, request)
+
+	response := responseWriter.Result()
+	assert.Equal(t, http.StatusOK, response.StatusCode, "should be successful request")
+
+	cookie := getResponseCookieByName(response, "_TRAEFIK_BACKEND")
+	assert.Equal(t, "http://2.3.4.5", cookie, "should have a valid backend")
+	assert.Equal(t, "http://2.3.4.5", response.Header.Get("X-Traefik-Backend"), "should have a sticky header")
+}
+
+func TestStickyHeaderPrefersBackendFromCookie(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie, _ := r.Cookie("_TRAEFIK_BACKEND")
+		assert.Equal(t, "http://0.0.0.2", cookie.Value, "should have a backend from cookie")
+		w.WriteHeader(http.StatusOK)
+	})
+	stickyHeader := NewStickyHeader(handler)
+	responseWriter := httptest.NewRecorder()
+
+	request, _ := http.NewRequest("GET", "http://example.com?X-Traefik-Backend=http://0.0.0.1", nil)
+	request.AddCookie(&http.Cookie{Name: "_TRAEFIK_BACKEND", Value: "http://0.0.0.2"})
+	stickyHeader.ServeHTTP(responseWriter, request)
+
+	response := responseWriter.Result()
+	assert.Equal(t, http.StatusOK, response.StatusCode, "should be successful request")
+
+	responseCookie := getResponseCookieByName(response, "_TRAEFIK_BACKEND")
+	assert.Equal(t, "", responseCookie, "should have no response cookie")
+	assert.Equal(t, 0, len(response.Header["X-Traefik-Backend"]), "should have no sticky header")
+}
+
+func getResponseCookieByName(response *http.Response, name string) string {
+	for _, cookie := range response.Cookies() {
+		if name == cookie.Name {
+			return cookie.Value
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Currently all cookies are session based (they expire when the browser is
closed). We currently use local storage to keep the information sent
from the custom headers which does not have expiration time.

Use case:
1. User visits site A - we set a cookie and local storage (both have value
X)
2. User closes the browser - this clears the cookie
3. User visits site A - we see there's X in local storage. So we use
this.
4. User visits site B - no cookie, no local storage, so we set the
cookie and local storage (both have value Y)
5. User now making requests on site A will take him from backend X to
backend Y because now a cookie is present which breaks the stickyness.

This PR makes sure we send a Set-Cookie header with the backend from the
query if it was valid.

EN-1957